### PR TITLE
add 'User Cancelled' error

### DIFF
--- a/China.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/China.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/MonkeyKing+Error.swift
+++ b/Sources/MonkeyKing+Error.swift
@@ -7,6 +7,7 @@ extension MonkeyKing {
         case noAccount
         case messageCanNotBeDelivered
         case invalidImageData
+        case userCancelled
 
         public enum SDKReason {
             case unknown
@@ -70,6 +71,8 @@ extension MonkeyKing.Error: LocalizedError {
             return "There no invalid developer account."
         case .messageCanNotBeDelivered:
             return "Message can't be delivered."
+        case .userCancelled:
+            return "User Cancelled"
         case .apiRequest(reason: let reason):
             switch reason.type {
             case .invalidToken:

--- a/Sources/MonkeyKing.swift
+++ b/Sources/MonkeyKing.swift
@@ -192,7 +192,8 @@ extension MonkeyKing {
 
                     // OAuth Failed
                     if let state = info["state"] as? String, state == "Weixinauth", resultCode != 0 {
-                        let error = NSError(domain: "WeChat OAuth Error", code: -1, userInfo: nil)
+                        let error: Swift.Error = resultCode == -2 ? Error.userCancelled : NSError(domain: "WeChat OAuth Error", code: resultCode, userInfo: nil)
+                        
                         shared.oauthCompletionHandler?(nil, nil, error)
                         return false
                     }
@@ -238,7 +239,7 @@ extension MonkeyKing {
             }
             guard let result = info["ret"] as? Int, result == 0 else {
                 if let errorDomatin = info["user_cancelled"] as? String, errorDomatin == "YES" {
-                    error = NSError(domain: "User Cancelled", code: -2, userInfo: nil)
+                    error = Error.userCancelled
                 } else {
                     error = NSError(domain: "OAuth Error", code: -1, userInfo: nil)
                 }


### PR DESCRIPTION
在 API 调用方看，一般期望用户主动取消授权不报错，其他错误才显示给用户，所以期望独立出一个 `User Cancelled`  Error.