### PR TITLE
新增微信文件分享

### DIFF
--- a/China/Base.lproj/Main.storyboard
+++ b/China/Base.lproj/Main.storyboard
@@ -228,6 +228,13 @@
                                     <action selector="shareGIF:" destination="2Fh-zG-2iM" eventType="touchUpInside" id="7Ze-ed-bfb"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oaF-Tr-K6G">
+                                <rect key="frame" x="172.5" y="480" width="30" height="30"/>
+                                <state key="normal" title="File"/>
+                                <connections>
+                                    <action selector="shareFile:" destination="2Fh-zG-2iM" eventType="touchUpInside" id="LpV-fr-Pbu"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
@@ -238,7 +245,9 @@
                             <constraint firstItem="wfw-9a-DtS" firstAttribute="top" secondItem="UWw-uP-3po" secondAttribute="bottom" constant="120" id="7ew-1Y-cIR"/>
                             <constraint firstItem="oRX-XU-uEu" firstAttribute="top" secondItem="UWw-uP-3po" secondAttribute="bottom" constant="10" id="8SX-ii-Vch"/>
                             <constraint firstItem="7zS-bL-oQf" firstAttribute="top" secondItem="sOl-Wo-bDF" secondAttribute="bottom" constant="20" id="Bnu-ad-MWc"/>
+                            <constraint firstItem="oaF-Tr-K6G" firstAttribute="top" secondItem="0hN-D7-bH1" secondAttribute="bottom" constant="8" id="C0u-Xn-Lrc"/>
                             <constraint firstItem="wO8-N9-PEd" firstAttribute="top" secondItem="gS0-c6-rje" secondAttribute="bottom" constant="10" id="HbP-Tg-KBy"/>
+                            <constraint firstItem="oaF-Tr-K6G" firstAttribute="centerX" secondItem="pco-JT-UnQ" secondAttribute="centerX" id="JDe-vE-dty"/>
                             <constraint firstItem="Wyh-QX-rAS" firstAttribute="centerX" secondItem="pco-JT-UnQ" secondAttribute="centerX" id="JGx-Bi-lsD"/>
                             <constraint firstItem="oRX-XU-uEu" firstAttribute="centerX" secondItem="UWw-uP-3po" secondAttribute="centerX" id="LMc-TR-Xjx"/>
                             <constraint firstItem="w7J-ug-Mpj" firstAttribute="centerX" secondItem="pco-JT-UnQ" secondAttribute="centerX" id="M4K-Ja-Rwp"/>

--- a/China/QQViewController.swift
+++ b/China/QQViewController.swift
@@ -75,7 +75,7 @@ class QQViewController: UIViewController {
                 title: "Dataline File, \(UUID().uuidString)",
                 description: "pay.php",
                 thumbnail: nil,
-                media: .file(fileData)
+                media: .file(fileData, fileExt: nil)
             )
             shareInfo(info)
         } catch {

--- a/China/WeChatViewController.swift
+++ b/China/WeChatViewController.swift
@@ -87,6 +87,21 @@ class WeChatViewController: UIViewController {
         )
         shareInfo(info)
     }
+
+    @IBAction func shareFile(_ sender: UIButton) {
+        do {
+            let fileData = try Data(contentsOf: URL(fileURLWithPath: Bundle.main.path(forResource: "gif", ofType: "gif")!))
+            let info = MonkeyKing.Info(
+                title: "File, \(UUID().uuidString)",
+                description: "Description File, \(UUID().uuidString)",
+                thumbnail: nil,
+                media: .file(fileData, fileExt: "gif")
+            )
+            shareInfo(info)
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
     
     private func shareInfo(_ info: MonkeyKing.Info) {
         var message: MonkeyKing.Message?

--- a/Sources/MonkeyKing.swift
+++ b/Sources/MonkeyKing.swift
@@ -673,9 +673,13 @@ extension MonkeyKing {
                     } 
                 case .file(let fileData, let fileExt):
                     weChatMessageInfo["objectType"] = "6"
-                    weChatMessageInfo["title"] = info.title
                     weChatMessageInfo["fileData"] = fileData
                     weChatMessageInfo["fileExt"] = fileExt
+
+                    if let fileExt = fileExt, let title = info.title {
+                        let suffix = ".\(fileExt)"
+                        weChatMessageInfo["title"] = title.hasSuffix(suffix) ? title : title + suffix
+                    }
                 }
             } else { // Text Share
                 weChatMessageInfo["command"] = "1020"

--- a/Sources/MonkeyKing.swift
+++ b/Sources/MonkeyKing.swift
@@ -436,7 +436,7 @@ extension MonkeyKing {
         case gif(Data)
         case audio(audioURL: URL, linkURL: URL?)
         case video(URL)
-        case file(Data)
+        case file(Data, fileExt: String?) /// file extension for wechat file share
         case miniApp(url: URL, path: String, withShareTicket: Bool, type: MiniAppType)
     }
 
@@ -671,8 +671,11 @@ extension MonkeyKing {
                             fatalError("Missing `miniProgramID`!")
                         }
                     } 
-                case .file:
-                    fatalError("WeChat not supports File type")
+                case .file(let fileData, let fileExt):
+                    weChatMessageInfo["objectType"] = "6"
+                    weChatMessageInfo["title"] = info.title
+                    weChatMessageInfo["fileData"] = fileData
+                    weChatMessageInfo["fileExt"] = fileExt
                 }
             } else { // Text Share
                 weChatMessageInfo["command"] = "1020"
@@ -750,7 +753,7 @@ extension MonkeyKing {
                     handleNews(with: audioURL, mediaType: "audio")
                 case .video(let url):
                     handleNews(with: url, mediaType: nil) // No video type, default is news type.
-                case .file(let fileData):
+                case .file(let fileData, _):
                     var dic: [String: Any] = ["file_data": fileData]
                     if let oldText = UIPasteboard.general.oldText {
                         dic["pasted_string"] = oldText


### PR DESCRIPTION
增加微信文件分享功能，需要对分享的文件添加 fileExt 参数，否则默认为 .dat