### PR TITLE
Refactor/extension

### DIFF
--- a/Sources/Extensions.swift
+++ b/Sources/Extensions.swift
@@ -127,11 +127,9 @@ extension String {
 extension Data {
 
     var monkeyking_json: [String: Any]? {
-        do {
-            return try JSONSerialization.jsonObject(with: self, options: .allowFragments) as? [String: Any]
-        } catch {
-            return nil
-        }
+        let json = try? JSONSerialization.jsonObject(with: self, options: .allowFragments)
+
+        return json as? [String: Any]
     }
 }
 

--- a/Sources/Extensions.swift
+++ b/Sources/Extensions.swift
@@ -137,18 +137,18 @@ extension Data {
 
 extension URL {
 
-    var monkeyking_queryDictionary: [String: Any] {
-        let components = URLComponents(url: self, resolvingAgainstBaseURL: false)
-        guard let items = components?.queryItems else {
+    var monkeyking_queryDictionary: [String: String] {
+        guard
+            let components = URLComponents(url: self, resolvingAgainstBaseURL: false),
+            let queryItems = components.queryItems
+        else {
             return [:]
         }
-        var infos = [String: Any]()
-        items.forEach {
-            if let value = $0.value {
-                infos[$0.name] = value
-            }
-        }
-        return infos
+
+        let items = queryItems.compactMap { $0.value != nil ? ($0.name, $0.value!) : nil }
+        let dict = Dictionary(items, uniquingKeysWith: { _, last in last })
+
+        return dict
     }
 }
 

--- a/Sources/Helpers.swift
+++ b/Sources/Helpers.swift
@@ -6,21 +6,32 @@ extension MonkeyKing {
     class func fetchWeChatOAuthInfoByCode(code: String, completionHandler: @escaping OAuthCompletionHandler) {
         var appID = ""
         var appKey = ""
+
         for case let .weChat(id, key, _) in shared.accountSet {
             guard let key = key else {
                 completionHandler(["code": code], nil, nil)
                 return
             }
+
             appID = id
             appKey = key
         }
-        var accessTokenAPI = "https://api.weixin.qq.com/sns/oauth2/access_token"
-        accessTokenAPI += "?grant_type=authorization_code"
-        accessTokenAPI += "&appid=\(appID)"
-        accessTokenAPI += "&secret=\(appKey)"
-        accessTokenAPI += "&code=\(code)"
+
+        var urlComponents = URLComponents(string: "https://api.weixin.qq.com/sns/oauth2/access_token")
+        urlComponents?.queryItems = [
+            URLQueryItem(name: "grant_type", value: "authorization_code"),
+            URLQueryItem(name: "appid", value: appID),
+            URLQueryItem(name: "secret", value: appKey),
+            URLQueryItem(name: "code", value: code)
+        ]
+
+        guard let accessTokenAPI = urlComponents?.string else {
+            completionHandler(["code": code], nil, nil)
+            return
+        }
+
         // OAuth
-        shared.request(accessTokenAPI, method: .get) { (json, response, error) in
+        shared.request(accessTokenAPI, method: .get) { json, response, error in
             completionHandler(json, response, error)
         }
     }

--- a/Sources/MonkeyKing+WebView.swift
+++ b/Sources/MonkeyKing+WebView.swift
@@ -51,7 +51,7 @@ extension MonkeyKing: WKNavigationDelegate {
         for case let .twitter(appID, appKey, redirectURL) in accountSet {
             guard url.absoluteString.hasPrefix(redirectURL) else { break }
             let params = url.monkeyking_queryDictionary
-            guard let token = params["oauth_token"] as? String, let verifer = params["oauth_verifier"] as? String else { break }
+            guard let token = params["oauth_token"], let verifer = params["oauth_verifier"] else { break }
             let accessTokenAPI = "https://api.twitter.com/oauth/access_token"
             let parameters = ["oauth_token": token, "oauth_verifier": verifer]
             let headerString = Networking.shared.authorizationHeader(for: .post, urlString: accessTokenAPI, appID: appID, appKey: appKey, accessToken: nil, accessTokenSecret: nil, parameters: parameters, isMediaUpload: false)
@@ -79,7 +79,7 @@ extension MonkeyKing: WKNavigationDelegate {
         // WeChat OAuth
         if url.absoluteString.hasPrefix("wx") {
             let queryDictionary = url.monkeyking_queryDictionary
-            guard let code = queryDictionary["code"] as? String else {
+            guard let code = queryDictionary["code"] else {
                 return
             }
             MonkeyKing.fetchWeChatOAuthInfoByCode(code: code) { [weak self] (info, response, error) in
@@ -89,7 +89,7 @@ extension MonkeyKing: WKNavigationDelegate {
             // Weibo OAuth
             for case let .weibo(_, _, redirectURL) in accountSet {
                 if url.absoluteString.hasPrefix(redirectURL) {
-                    guard let code = url.monkeyking_queryDictionary["code"] as? String else { return }
+                    guard let code = url.monkeyking_queryDictionary["code"] else { return }
                     MonkeyKing.fetchWeiboOAuthInfoByCode(code: code) { [weak self] info, response, error in
                         self?.removeWebView(webView, tuples: (info, response, error))
                     }

--- a/Sources/MonkeyKing.swift
+++ b/Sources/MonkeyKing.swift
@@ -686,7 +686,7 @@ extension MonkeyKing {
             if let oldText = UIPasteboard.general.oldText {
                 weChatMessage["old_text"] = oldText
             }
-            guard let data = try? PropertyListSerialization.data(fromPropertyList: weChatMessage, format: .binary, options: 0) else { return }
+            guard let data = try? PropertyListSerialization.data(fromPropertyList: weChatMessage, format: .binary, options: .init()) else { return }
             UIPasteboard.general.setData(data, forPasteboardType: "content")
             let weChatSchemeURLString = "weixin://app/\(appID)/sendreq/?"
             openURL(urlString: weChatSchemeURLString) { flag in
@@ -953,7 +953,7 @@ extension MonkeyKing {
             }
         case .alipay(let type):
             let dictionary = createAlipayMessageDictionary(withScene: type.scene, info: type.info, appID: appID)
-            guard let data = try? PropertyListSerialization.data(fromPropertyList: dictionary, format: .xml, options: 0) else {
+            guard let data = try? PropertyListSerialization.data(fromPropertyList: dictionary, format: .xml, options: .init()) else {
                 completionHandler(.failure(.sdk(reason: .serializeFailed)))
                 return
             }

--- a/Sources/MonkeyKing.swift
+++ b/Sources/MonkeyKing.swift
@@ -95,7 +95,22 @@ public class MonkeyKing: NSObject {
         }
 
         public static func ==(lhs: MonkeyKing.Account, rhs: MonkeyKing.Account) -> Bool {
-            return lhs.appID == rhs.appID
+            switch (lhs, rhs) {
+            case (.weChat(let lappID, _, _), .weChat(let rappID, _, _)),
+                 (.qq(let lappID), .qq(let rappID)),
+                 (.weibo(let lappID, _, _), .weibo(let rappID, _, _)),
+                 (.pocket(let lappID), .pocket(let rappID)),
+                 (.alipay(let lappID), .alipay(let rappID)),
+                 (.twitter(let lappID, _, _), .twitter(let rappID, _, _)):
+                return lappID == rappID
+            case (.weChat, _),
+                 (.qq, _),
+                 (.weibo, _),
+                 (.pocket, _),
+                 (.alipay, _),
+                 (.twitter, _):
+                return false
+            }
         }
     }
 

--- a/Sources/MonkeyKing.swift
+++ b/Sources/MonkeyKing.swift
@@ -165,7 +165,7 @@ extension MonkeyKing {
             // OAuth
             if urlString.contains("state=Weixinauth") {
                 let queryDictionary = url.monkeyking_queryDictionary
-                guard let code = queryDictionary["code"] as? String else {
+                guard let code = queryDictionary["code"] else {
                     shared.weChatOAuthForCodeCompletionHandler = nil
                     return false
                 }
@@ -183,8 +183,8 @@ extension MonkeyKing {
             // SMS OAuth
             if urlString.contains("wapoauth") {
                 let queryDictionary = url.monkeyking_queryDictionary
-                guard let m = queryDictionary["m"] as? String else { return false }
-                guard let t = queryDictionary["t"] as? String else { return false }
+                guard let m = queryDictionary["m"] else { return false }
+                guard let t = queryDictionary["t"] else { return false }
                 guard let account = shared.accountSet[.weChat] else { return false }
                 let appID = account.appID
                 let urlString = "https://open.weixin.qq.com/connect/smsauthorize?appid=\(appID)&redirect_uri=\(appID)%3A%2F%2Foauth&response_type=code&scope=snsapi_message,snsapi_userinfo,snsapi_friend,snsapi_contact&state=xxx&uid=1926559385&m=\(m)&t=\(t)"
@@ -198,7 +198,7 @@ extension MonkeyKing {
                     shared.payCompletionHandler?(result)
                 }
                 let queryDictionary = url.monkeyking_queryDictionary
-                guard let ret = queryDictionary["ret"] as? String else { return false }
+                guard let ret = queryDictionary["ret"] else { return false }
                 result = (ret == "0")
                 return result
             }
@@ -252,7 +252,7 @@ extension MonkeyKing {
 
         // QQ Share
         if urlScheme.hasPrefix("QQ") {
-            guard let errorDescription = url.monkeyking_queryDictionary["error"] as? String else { return false }
+            guard let errorDescription = url.monkeyking_queryDictionary["error"] else { return false }
             let success = (errorDescription == "0")
             if success {
                 shared.deliverCompletionHandler?(.success(nil))
@@ -382,7 +382,7 @@ extension MonkeyKing {
                     defer {
                         shared.oauthCompletionHandler?(resultDic, nil, error)
                     }
-                    if let _ = resultDic["auth_code"], let _ = resultDic["scope"] as? String {
+                    if let _ = resultDic["auth_code"], let _ = resultDic["scope"] {
                         return true
                     }
                     error = NSError(domain: "OAuth Error", code: -1, userInfo: nil)

--- a/Sources/MonkeyKing.swift
+++ b/Sources/MonkeyKing.swift
@@ -204,7 +204,7 @@ extension MonkeyKing {
             }
 
             if let data = UIPasteboard.general.data(forPasteboardType: "content") {
-                if let dict = try? PropertyListSerialization.propertyList(from: data, options: PropertyListSerialization.MutabilityOptions(), format: nil) as? [String: Any] {
+                if let dict = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] {
 
                     guard
                         let account = shared.accountSet[.weChat],
@@ -394,7 +394,7 @@ extension MonkeyKing {
             } else { // Share
                 guard
                     let data = UIPasteboard.general.data(forPasteboardType: "com.alipay.openapi.pb.resp.\(appID)"),
-                    let dict = try? PropertyListSerialization.propertyList(from: data, options: PropertyListSerialization.MutabilityOptions(), format: nil) as? [String: Any],
+                    let dict = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
                     let objects = dict["$objects"] as? NSArray,
                     let result = objects[12] as? Int else {
                         return false

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -156,7 +156,7 @@ class Networking {
                 }
             }
             guard let validData = data,
-                let jsonData = try? JSONSerialization.jsonObject(with: validData, options: .allowFragments) as? [String: Any] else {
+                let jsonData = validData.monkeyking_json else {
                     print("requst fail: JSON could not be serialized because input data was nil.")
                     return
             }
@@ -184,7 +184,7 @@ class Networking {
                 }
             }
             guard let validData = data,
-                let jsonData = try? JSONSerialization.jsonObject(with: validData, options: .allowFragments) as? [String: Any] else {
+                let jsonData = validData.monkeyking_json else {
                     print("upload fail: JSON could not be serialized because input data was nil.")
                     return
             }

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -74,8 +74,7 @@ class Networking {
                 }
             case .json:
                 do {
-                    let options = JSONSerialization.WritingOptions()
-                    let data = try JSONSerialization.data(withJSONObject: parameters, options: options)
+                    let data = try JSONSerialization.data(withJSONObject: parameters)
                     mutableURLRequest.setValue("application/json; charset=UTF-8", forHTTPHeaderField: "Content-Type")
                     mutableURLRequest.setValue("application/json", forHTTPHeaderField: "X-Accept")
                     mutableURLRequest.httpBody = data


### PR DESCRIPTION
# MonkeyKing.Account

1. 之前的 `Equatable` 极小概率发生碰撞。
2. lhs 和 rhs 匹配相同 case，直接 `return lhs.appID == rhs.appID` 看起来更简洁，但是 `.appID` 会再走两次匹配，在外部可以直接绑定。
3. `Hashable` 和 `Equatable` 已经支持带关联值的 enum 自动合成了。

# Swift.Result

1. 不知道是否有考虑使用 Swift.Result 重构 `DeliverResult`？，这应该是破坏性更新了。

---

不相关的提交堆在一个分支了，下次应该拆开？😂
