### PR TITLE
支持微信 Universal Link

### DIFF
--- a/China.xcodeproj/project.pbxproj
+++ b/China.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		50FBA6D71BA2BBE900E69BB3 /* MonkeyKing.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 50FBA6CF1BA2BBE900E69BB3 /* MonkeyKing.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7840AF1D1C63167C00AD5256 /* pay.php in Resources */ = {isa = PBXBuildFile; fileRef = 7840AF1C1C63167C00AD5256 /* pay.php */; };
 		955654EB1EB89D5D009444FF /* TwitterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955654EA1EB89D5D009444FF /* TwitterViewController.swift */; };
+		D79F73B42491F5EB00B4B883 /* MonkeyKing+WeChatUniversalLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = D79F73B32491F5EB00B4B883 /* MonkeyKing+WeChatUniversalLink.swift */; };
 		EDD0A28C213E6F7B003EB202 /* WeChatActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD0A28A213E6F7B003EB202 /* WeChatActivity.swift */; };
 		EDD0A28D213E6F7B003EB202 /* QQActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD0A28B213E6F7B003EB202 /* QQActivity.swift */; };
 		EDD0A28F213E6FB2003EB202 /* gif.gif in Resources */ = {isa = PBXBuildFile; fileRef = EDD0A28E213E6FB2003EB202 /* gif.gif */; };
@@ -103,6 +104,10 @@
 		50FBA6D31BA2BBE900E69BB3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7840AF1C1C63167C00AD5256 /* pay.php */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.php; path = pay.php; sourceTree = "<group>"; };
 		955654EA1EB89D5D009444FF /* TwitterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TwitterViewController.swift; sourceTree = "<group>"; };
+		D79F73B32491F5EB00B4B883 /* MonkeyKing+WeChatUniversalLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MonkeyKing+WeChatUniversalLink.swift"; sourceTree = "<group>"; };
+		D79F73B524920FBC00B4B883 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		D79F73B624920FBC00B4B883 /* MonkeyKing.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = MonkeyKing.podspec; sourceTree = "<group>"; };
+		D79F73B724920FBC00B4B883 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		EDD0A28A213E6F7B003EB202 /* WeChatActivity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeChatActivity.swift; sourceTree = "<group>"; };
 		EDD0A28B213E6F7B003EB202 /* QQActivity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QQActivity.swift; sourceTree = "<group>"; };
 		EDD0A28E213E6FB2003EB202 /* gif.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = gif.gif; sourceTree = "<group>"; };
@@ -130,6 +135,9 @@
 		50FBA6AC1BA2AFAD00E69BB3 = {
 			isa = PBXGroup;
 			children = (
+				D79F73B724920FBC00B4B883 /* README.md */,
+				D79F73B624920FBC00B4B883 /* MonkeyKing.podspec */,
+				D79F73B524920FBC00B4B883 /* Package.swift */,
 				50FBA6B71BA2AFAD00E69BB3 /* China */,
 				50FBA6D01BA2BBE900E69BB3 /* MonkeyKing */,
 				50FBA6B61BA2AFAD00E69BB3 /* Products */,
@@ -180,6 +188,7 @@
 				10CDDF43237A8588005E8DE7 /* Helpers.swift */,
 				10CDDF3F237A8588005E8DE7 /* MonkeyKing.swift */,
 				10CDDF45237A8588005E8DE7 /* MonkeyKing+Error.swift */,
+				D79F73B32491F5EB00B4B883 /* MonkeyKing+WeChatUniversalLink.swift */,
 				07211C7223B8D1AA0068A7C0 /* MonkeyKing+handleOpenURL.swift */,
 				07211C7823B8D37E0068A7C0 /* MonkeyKing+Message.swift */,
 				07211C7A23B8D3A60068A7C0 /* MonkeyKing+OAuth.swift */,
@@ -354,6 +363,7 @@
 				10CDDF4B237A8588005E8DE7 /* Extensions.swift in Sources */,
 				07211C7923B8D37E0068A7C0 /* MonkeyKing+Message.swift in Sources */,
 				10CDDF49237A8588005E8DE7 /* AnyActivity.swift in Sources */,
+				D79F73B42491F5EB00B4B883 /* MonkeyKing+WeChatUniversalLink.swift in Sources */,
 				07211C7723B8D2FD0068A7C0 /* MonkeyKing+Pay.swift in Sources */,
 				10CDDF46237A8588005E8DE7 /* MonkeyKing.swift in Sources */,
 				10CDDF4A237A8588005E8DE7 /* Helpers.swift in Sources */,

--- a/China.xcodeproj/project.pbxproj
+++ b/China.xcodeproj/project.pbxproj
@@ -39,7 +39,7 @@
 		50FBA6D71BA2BBE900E69BB3 /* MonkeyKing.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 50FBA6CF1BA2BBE900E69BB3 /* MonkeyKing.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7840AF1D1C63167C00AD5256 /* pay.php in Resources */ = {isa = PBXBuildFile; fileRef = 7840AF1C1C63167C00AD5256 /* pay.php */; };
 		955654EB1EB89D5D009444FF /* TwitterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955654EA1EB89D5D009444FF /* TwitterViewController.swift */; };
-		D79F73B42491F5EB00B4B883 /* MonkeyKing+WeChatUniversalLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = D79F73B32491F5EB00B4B883 /* MonkeyKing+WeChatUniversalLink.swift */; };
+		D71A624424D313E5002B2977 /* MonkeyKing+WeChatUniversalLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = D71A624324D313E5002B2977 /* MonkeyKing+WeChatUniversalLink.swift */; };
 		EDD0A28C213E6F7B003EB202 /* WeChatActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD0A28A213E6F7B003EB202 /* WeChatActivity.swift */; };
 		EDD0A28D213E6F7B003EB202 /* QQActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD0A28B213E6F7B003EB202 /* QQActivity.swift */; };
 		EDD0A28F213E6FB2003EB202 /* gif.gif in Resources */ = {isa = PBXBuildFile; fileRef = EDD0A28E213E6FB2003EB202 /* gif.gif */; };
@@ -104,7 +104,7 @@
 		50FBA6D31BA2BBE900E69BB3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7840AF1C1C63167C00AD5256 /* pay.php */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.php; path = pay.php; sourceTree = "<group>"; };
 		955654EA1EB89D5D009444FF /* TwitterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TwitterViewController.swift; sourceTree = "<group>"; };
-		D79F73B32491F5EB00B4B883 /* MonkeyKing+WeChatUniversalLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MonkeyKing+WeChatUniversalLink.swift"; sourceTree = "<group>"; };
+		D71A624324D313E5002B2977 /* MonkeyKing+WeChatUniversalLink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "MonkeyKing+WeChatUniversalLink.swift"; path = "Sources/MonkeyKing/MonkeyKing+WeChatUniversalLink.swift"; sourceTree = SOURCE_ROOT; };
 		D79F73B524920FBC00B4B883 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		D79F73B624920FBC00B4B883 /* MonkeyKing.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = MonkeyKing.podspec; sourceTree = "<group>"; };
 		D79F73B724920FBC00B4B883 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -188,8 +188,8 @@
 				10CDDF43237A8588005E8DE7 /* Helpers.swift */,
 				10CDDF3F237A8588005E8DE7 /* MonkeyKing.swift */,
 				10CDDF45237A8588005E8DE7 /* MonkeyKing+Error.swift */,
-				D79F73B32491F5EB00B4B883 /* MonkeyKing+WeChatUniversalLink.swift */,
 				07211C7223B8D1AA0068A7C0 /* MonkeyKing+handleOpenURL.swift */,
+				D71A624324D313E5002B2977 /* MonkeyKing+WeChatUniversalLink.swift */,
 				07211C7823B8D37E0068A7C0 /* MonkeyKing+Message.swift */,
 				07211C7A23B8D3A60068A7C0 /* MonkeyKing+OAuth.swift */,
 				07211C7E23B8D44C0068A7C0 /* MonkeyKing+OpenURL.swift */,
@@ -361,9 +361,9 @@
 				07211C7F23B8D44C0068A7C0 /* MonkeyKing+OpenURL.swift in Sources */,
 				10CDDF4C237A8588005E8DE7 /* MonkeyKing+Error.swift in Sources */,
 				10CDDF4B237A8588005E8DE7 /* Extensions.swift in Sources */,
+				D71A624424D313E5002B2977 /* MonkeyKing+WeChatUniversalLink.swift in Sources */,
 				07211C7923B8D37E0068A7C0 /* MonkeyKing+Message.swift in Sources */,
 				10CDDF49237A8588005E8DE7 /* AnyActivity.swift in Sources */,
-				D79F73B42491F5EB00B4B883 /* MonkeyKing+WeChatUniversalLink.swift in Sources */,
 				07211C7723B8D2FD0068A7C0 /* MonkeyKing+Pay.swift in Sources */,
 				10CDDF46237A8588005E8DE7 /* MonkeyKing.swift in Sources */,
 				10CDDF4A237A8588005E8DE7 /* Helpers.swift in Sources */,

--- a/China/Activities/WeChatActivity.swift
+++ b/China/Activities/WeChatActivity.swift
@@ -36,7 +36,14 @@ class WeChatActivity: AnyActivity {
     }
 
     init(type: Type, message: MonkeyKing.Message, completionHandler: @escaping MonkeyKing.DeliverCompletionHandler) {
-        MonkeyKing.registerAccount(.weChat(appID: Configs.WeChat.appID, appKey: nil, miniAppID: nil))
+        MonkeyKing.registerAccount(
+            .weChat(
+                appID: Configs.WeChat.appID,
+                appKey: nil,
+                miniAppID: nil,
+                universalLink: Configs.WeChat.universalLink
+            )
+        )
         super.init(
             type: type.activityType,
             title: type.title,

--- a/China/AppDelegate.swift
+++ b/China/AppDelegate.swift
@@ -14,9 +14,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        if MonkeyKing.handleOpenURL(url) {
-            return true
-        }
-        return false
+        return MonkeyKing.handleOpenURL(url)
+    }
+
+    func application(_ application: UIApplication, handleOpen url: URL) -> Bool {
+        return MonkeyKing.handleOpenURL(url)
+    }
+
+    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+        MonkeyKing.handleOpenUserActivity(userActivity)
+        return true
     }
 }

--- a/China/AppDelegate.swift
+++ b/China/AppDelegate.swift
@@ -22,7 +22,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        MonkeyKing.handleOpenUserActivity(userActivity)
-        return true
+        return MonkeyKing.handleOpenUserActivity(userActivity)
     }
 }

--- a/China/Configs.swift
+++ b/China/Configs.swift
@@ -13,6 +13,7 @@ struct Configs {
         static let appID = "wx4868b35061f87885"
         static let appKey = "64020361b8ec4c99936c0e3999a9f249"
         static let miniAppID = "gh_d43f693ca31f"
+        static let universalLink = "YOUR_UNIVERSAL_LINK"
     }
 
     struct QQ {

--- a/China/Info.plist
+++ b/China/Info.plist
@@ -95,6 +95,7 @@
 		<string>weibosdk</string>
 		<string>alipay</string>
 		<string>alipayshare</string>
+		<string>weixinULAPI</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>

--- a/China/SystemShareViewController.swift
+++ b/China/SystemShareViewController.swift
@@ -5,7 +5,14 @@ import UIKit
 class SystemShareViewController: UIViewController {
 
     @IBAction func systemShare(_ sender: UIButton) {
-        MonkeyKing.registerAccount(.weChat(appID: Configs.WeChat.appID, appKey: Configs.WeChat.appKey, miniAppID: nil))
+        MonkeyKing.registerAccount(
+            .weChat(
+                appID: Configs.WeChat.appID,
+                appKey: Configs.WeChat.appKey,
+                miniAppID: nil,
+                universalLink: Configs.WeChat.universalLink
+            )
+        )
         let shareURL = URL(string: "http://www.apple.com/cn/iphone/compare/")!
         let info = MonkeyKing.Info(
             title: "iPhone Compare",

--- a/China/WeChatViewController.swift
+++ b/China/WeChatViewController.swift
@@ -10,7 +10,7 @@ class WeChatViewController: UIViewController {
         super.viewDidLoad()
 
         // Should not register account here
-        let account = MonkeyKing.Account.weChat(appID: Configs.WeChat.appID, appKey: Configs.WeChat.appKey, miniAppID: Configs.WeChat.miniAppID)
+        let account = MonkeyKing.Account.weChat(appID: Configs.WeChat.appID, appKey: Configs.WeChat.appKey, miniAppID: Configs.WeChat.miniAppID, universalLink: Configs.WeChat.universalLink)
         MonkeyKing.registerAccount(account)
     }
 
@@ -150,7 +150,11 @@ extension WeChatViewController {
 
     @IBAction func OAuthWithoutAppKey(_ sender: UIButton) {
         // Should not register account here
-        let accountWithoutAppKey = MonkeyKing.Account.weChat(appID: Configs.WeChat.appID, appKey: nil, miniAppID: nil)
+        let accountWithoutAppKey = MonkeyKing.Account.weChat(
+            appID: Configs.WeChat.appID,
+            appKey: nil,
+            miniAppID: nil,
+            universalLink: Configs.WeChat.universalLink)
         MonkeyKing.registerAccount(accountWithoutAppKey)
 
         MonkeyKing.oauth(for: .weChat) { result in

--- a/MonkeyKing/MonkeyKing+WeChatUniversalLink.swift
+++ b/MonkeyKing/MonkeyKing+WeChatUniversalLink.swift
@@ -1,0 +1,111 @@
+//
+//  MonkeyKing+WeChatUniversalLink.swift
+//  MonkeyKing
+//
+//  Created by Lex on 2020/6/11.
+//  Copyright © 2020 nixWork. All rights reserved.
+//
+
+import Foundation
+import Security
+import CommonCrypto
+
+
+extension MonkeyKing {
+
+    private static var wechatAccount: String {
+        return "WeChatOpenSDKKeyChainAccount"
+    }
+
+    private static var wechatServiceName: String {
+        return "WeChatOpenSDKKeyChainService_\(Bundle.main.bundleIdentifier ?? "")"
+    }
+
+    static var lastMessage: Message? {
+        get {
+            return _lastMessage
+        }
+        set {
+            _lastMessage = newValue
+        }
+    }
+
+    // NOTE: Since the SHA1 algorithm is not reversible, it's not necessary to follow the original contentID in WechatOpenSDK
+    // NSString(format: "%@_%p_%@", timeIntervalSince1970, SendMessageToWXRed, autoIncreaseId)
+    static var wechatContextId: String {
+        _autoIncreaseId += 1
+        let str = String(format: "%f_%f", Date().timeIntervalSince1970, _autoIncreaseId)
+        return str.sha1()
+    }
+
+    static var wechatAuthToken: String? {
+        get {
+            let query = [
+                kSecAttrService as String: wechatServiceName,
+                kSecAttrAccount as String: wechatAccount,
+                kSecClass as String: kSecClassGenericPassword,
+                kSecMatchLimit as String: kSecMatchLimitOne,
+                kSecReturnData as String: true,
+                kSecReturnAttributes as String: true
+            ] as CFDictionary
+
+
+            var queryResult: AnyObject?
+            let status = withUnsafeMutablePointer(to: &queryResult) {
+                SecItemCopyMatching(query as CFDictionary, UnsafeMutablePointer($0))
+            }
+
+            guard status != errSecItemNotFound else { return nil }
+            guard status == noErr else { return nil }
+
+            guard let existingItem = queryResult as? [String: AnyObject],
+                let passwordData = existingItem[kSecValueData as String] as? Data,
+                let password = String(data: passwordData, encoding: String.Encoding.utf8)
+            else {
+                return nil
+            }
+            return password
+        }
+        set {
+            var query: [String: Any] = [
+                kSecAttrService as String: wechatServiceName,
+                kSecAttrAccount as String: wechatAccount,
+                kSecClass as String: kSecClassGenericPassword
+            ]
+
+            if let newValue = newValue, let valueData = newValue.data(using: .utf8, allowLossyConversion: false) {
+                SecItemDelete(query as CFDictionary)
+
+                query[String(kSecValueData)] = valueData
+                SecItemAdd(query as CFDictionary, nil)
+            } else {
+                SecItemDelete(query as CFDictionary)
+            }
+        }
+    }
+
+}
+
+extension String {
+
+    // NOTE: Obviously, we don't even have to use CommonCrypto
+    // In order to reduce the package size, we'll replace this implenmentation some day
+    func sha1() -> String {
+        let data = Data(self.utf8)
+        var digest = [UInt8](repeating: 0, count:Int(CC_SHA1_DIGEST_LENGTH))
+        data.withUnsafeBytes {
+            _ = CC_SHA1($0.baseAddress, CC_LONG(data.count), &digest)
+        }
+        let hexBytes = digest.map { String(format: "%02hhx", $0) }
+        return hexBytes.joined()
+    }
+}
+
+extension Data {
+    var hexDescription: String {
+        return reduce("") { $0 + String(format: "%02x", $1) }
+    }
+}
+
+private var _autoIncreaseId: UInt64 = 0
+private var _lastMessage: MonkeyKing.Message?

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@
 
 MonkeyKing helps you post SNS messages to Chinese Social Networks, without their buggy SDKs.
 
-MonkeyKing uses the same analysis process of [openshare](https://github.com/100apps/openshare), support share **Text**, **URL**, **Image**, **Audio**, **Video**, and **File** to **WeChat**, **QQ**, **Alipay** or **Weibo**. MonkeyKing can also post messages to Weibo by a webpage. (Note: Audio and Video are specifically for WeChat or QQ, File is only for QQ Dataline)
+MonkeyKing uses the same analysis process of [openshare](https://github.com/100apps/openshare).
+We also use some reverse engineering tools such as [Hopper Disassembler](https://www.hopperapp.com/) to unveil several undocumented authentication mechanisms under the hood.
+It supports sharing **Text**, **URL**, **Image**, **Audio**, **Video**, and **File** to **WeChat**, **QQ**, **Alipay** or **Weibo**.
+MonkeyKing can also post messages to Weibo by a web page. (Note: Audio and Video are exclusive to WeChat or QQ, and File is exclusive to QQ Dataline)
 
 MonkeyKing also supports **OAuth** and **Mobile payment** via WeChat and Alipay!
 
@@ -34,33 +37,44 @@ Example: Share to WeChat (微信)：
 1. In your Project Target's `Info.plist`, set `URL Type`, `LSApplicationQueriesSchemes` as follow:
 
     <img src="https://raw.githubusercontent.com/nixzhu/MonkeyKing/master/images/infoList.png" width="600">
+    
+    You should also add `weixinULAPI` once you enabled Universal Link of your WeChat App.
 
 2. Register account: // it's not necessary to do it here, but for the sake of convenience
 
     ```swift
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-
-        MonkeyKing.registerAccount(.weChat(appID: "xxx", appKey: "yyy", miniAppID: nil))
-
+        MonkeyKing.regsiterAccount(
+            .weChat(
+                appID: "xxx",
+                appKey: "yyy",
+                miniAppID: nil,
+                universalLink: nil // FIXME: You have to adopt Universal Link otherwise your app name becomes "Unauthorized App"(未验证应用)...
+            )
+        )
         return true
     }
     ```
 
-3. If you need to handle call back, add following code:
+3. Append the following code to handle callbacks:
 
     ```swift
+    // AppDelegate.swift
+    
     func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
     //func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool { // only for iOS 8
-
-        if MonkeyKing.handleOpenURL(url) {
-            return true
-        }
-
-        return false
+        return MonkeyKing.handleOpenURL(url)
     }
     ```
-
-    to your AppDelegate.
+    
+    Remember to handle userActivities if you are using `UIScene` in your project:
+    ```swift
+    // SceneDelegate.swift
+    
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        MonkeyKing.handleOpenUserActivity(userActivity)
+    }
+    ```
 
 4. Prepare your message and ask MonkeyKing to deliver it:
 

--- a/Sources/MonkeyKing/Extensions.swift
+++ b/Sources/MonkeyKing/Extensions.swift
@@ -113,6 +113,13 @@ extension URL {
     }
 }
 
+extension URLComponents {
+
+    func valueOfQueryItem(_ itemName: String) -> String? {
+        queryItems?.first(where: { $0.name == itemName })?.value
+    }
+}
+
 extension UIImage {
 
     var monkeyking_compressedImageData: Data? {

--- a/Sources/MonkeyKing/Helpers.swift
+++ b/Sources/MonkeyKing/Helpers.swift
@@ -7,7 +7,7 @@ extension MonkeyKing {
         var appID = ""
         var appKey = ""
 
-        for case .weChat(let id, let key, _) in shared.accountSet {
+        for case .weChat(let id, let key, _, _) in shared.accountSet {
             guard let key = key else {
                 completionHandler(.failure(.noAccount))
                 return

--- a/Sources/MonkeyKing/MonkeyKing+Message.swift
+++ b/Sources/MonkeyKing/MonkeyKing+Message.swift
@@ -273,22 +273,11 @@ extension MonkeyKing {
 
             var wxUrlOptions = [UIApplication.OpenExternalURLOptionsKey : Any]()
 
-            if let universalLink = account.universalLink, #available(iOS 10.0, *) {
+            if let universalLink = shared.wechatUniversalLink(of: "sendreq"), #available(iOS 10.0, *) {
+                wxUrlStr = universalLink
                 weChatMessageInfo["universalLink"] = universalLink
                 weChatMessageInfo["isAutoResend"] = false
                 wxUrlOptions[.universalLinksOnly] = true
-
-                let contextId = wechatContextId
-                let bundleId = Bundle.main.bundleIdentifier ?? ""
-                let allowedCharacterSet = CharacterSet(charactersIn: "!*'();:@&=+$,/?%#[] ^").inverted
-
-                if  let authToken = wechatAuthToken,
-                    let authTokenEncoded = NSString(string: authToken).addingPercentEncoding(withAllowedCharacters: allowedCharacterSet)
-                {
-                    wxUrlStr = "https://help.wechat.com/app/\(appID)/sendreq/?wechat_auth_token=\(authTokenEncoded)&wechat_auth_context_id=\(contextId)&wechat_app_bundleId=\(bundleId)"
-                } else {
-                    wxUrlStr = "https://help.wechat.com/app/\(appID)/sendreq/?wechat_auth_context_id=\(contextId)&wechat_app_bundleId=\(bundleId)"
-                }
             } else {
                 wxUrlStr = "weixin://app/\(appID)/sendreq/?"
             }

--- a/Sources/MonkeyKing/MonkeyKing+OAuth.swift
+++ b/Sources/MonkeyKing/MonkeyKing+OAuth.swift
@@ -48,7 +48,7 @@ extension MonkeyKing {
                 completionHandler(.failure(.sdk(.invalidURLScheme)))
             }
 
-        case .weChat(let appID, _, _):
+        case .weChat(let appID, _, _, _):
             let scope = scope ?? "snsapi_userinfo"
             if !platform.isAppInstalled {
                 // SMS OAuth
@@ -211,7 +211,7 @@ extension MonkeyKing {
         shared.oauthFromWeChatCodeCompletionHandler = completionHandler
 
         switch account {
-        case .weChat(let appID, _, _):
+        case .weChat(let appID, _, _, _):
             let scope = scope ?? "snsapi_userinfo"
 
             var urlComponents = URLComponents(string: "weixin://app/\(appID)/auth/")

--- a/Sources/MonkeyKing/MonkeyKing+WeChatUniversalLink.swift
+++ b/Sources/MonkeyKing/MonkeyKing+WeChatUniversalLink.swift
@@ -14,16 +14,16 @@ import CommonCrypto
 extension MonkeyKing {
 
     private static var wechatAccount: String {
-        return "WeChatOpenSDKKeyChainAccount"
+        "WeChatOpenSDKKeyChainAccount"
     }
 
     private static var wechatServiceName: String {
-        return "WeChatOpenSDKKeyChainService_\(Bundle.main.bundleIdentifier ?? "")"
+        "WeChatOpenSDKKeyChainService_\(Bundle.main.bundleIdentifier ?? "")"
     }
 
     static var lastMessage: Message? {
         get {
-            return _lastMessage
+            _lastMessage
         }
         set {
             _lastMessage = newValue
@@ -91,8 +91,8 @@ extension String {
     // NOTE: Obviously, we don't even have to use CommonCrypto
     // In order to reduce the package size, we'll replace this implenmentation some day
     func sha1() -> String {
-        let data = Data(self.utf8)
-        var digest = [UInt8](repeating: 0, count:Int(CC_SHA1_DIGEST_LENGTH))
+        let data = Data(utf8)
+        var digest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
         data.withUnsafeBytes {
             _ = CC_SHA1($0.baseAddress, CC_LONG(data.count), &digest)
         }
@@ -103,7 +103,7 @@ extension String {
 
 extension Data {
     var hexDescription: String {
-        return reduce("") { $0 + String(format: "%02x", $1) }
+        reduce("") { $0 + String(format: "%02x", $1) }
     }
 }
 

--- a/Sources/MonkeyKing/MonkeyKing+WeChatUniversalLink.swift
+++ b/Sources/MonkeyKing/MonkeyKing+WeChatUniversalLink.swift
@@ -84,6 +84,29 @@ extension MonkeyKing {
         }
     }
 
+    func wechatUniversalLink(of command: String) -> String? {
+        guard
+            #available(iOS 10.0, *),
+            let account = MonkeyKing.shared.accountSet[.weChat],
+            account.universalLink != nil
+        else {
+            return nil
+        }
+
+        let appID = account.appID
+        let contextId = MonkeyKing.wechatContextId
+        let bundleId = Bundle.main.bundleIdentifier ?? ""
+        let allowedCharacterSet = CharacterSet(charactersIn: "!*'();:@&=+$,/?%#[] ^").inverted
+
+        if  let authToken = MonkeyKing.wechatAuthToken,
+            let authTokenEncoded = NSString(string: authToken).addingPercentEncoding(withAllowedCharacters: allowedCharacterSet)
+        {
+            return "https://help.wechat.com/app/\(appID)/\(command)/?wechat_auth_token=\(authTokenEncoded)&wechat_auth_context_id=\(contextId)&wechat_app_bundleId=\(bundleId)"
+        } else {
+            return "https://help.wechat.com/app/\(appID)/\(command)/?wechat_auth_context_id=\(contextId)&wechat_app_bundleId=\(bundleId)"
+        }
+    }
+
 }
 
 extension String {

--- a/Sources/MonkeyKing/MonkeyKing+WeChatUniversalLink.swift
+++ b/Sources/MonkeyKing/MonkeyKing+WeChatUniversalLink.swift
@@ -107,6 +107,26 @@ extension MonkeyKing {
         }
     }
 
+    func setPasteboard(of appId: String, with content: [String: Any]) {
+        var weChatMessageInfo: [String: Any] = [
+            "result": "1",
+            "sdkver": "1.8.7.1",
+            "returnFromApp": "0",
+        ]
+
+        content.forEach { (key, value) in
+            weChatMessageInfo[key] = value
+        }
+
+        var weChatMessage: [String: Any] = [appId: weChatMessageInfo]
+        if let oldText = UIPasteboard.general.oldText {
+            weChatMessage["old_text"] = oldText
+        }
+
+        guard let data = try? PropertyListSerialization.data(fromPropertyList: weChatMessage, format: .binary, options: .init()) else { return }
+        UIPasteboard.general.setData(data, forPasteboardType: "content")
+    }
+
 }
 
 extension String {

--- a/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
+++ b/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
@@ -26,8 +26,6 @@ extension MonkeyKing {
             return false
         }
 
-        lastMessage = nil
-
         return true
     }
 
@@ -39,7 +37,10 @@ extension MonkeyKing {
             return false
         }
 
-        lastMessage.map { deliver($0) { _ in lastMessage = nil } }
+        if let msg = lastMessage {
+            deliver(msg) { _ in }
+        }
+        lastMessage = nil
 
         // MARK: - update token
         if let authToken = comps.valueOfQueryItem("wechat_auth_token"), !authToken.isEmpty {

--- a/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
+++ b/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
@@ -54,19 +54,15 @@ extension MonkeyKing {
         }
 
         // MARK: - pay
-        if  comps.path.hasSuffix("pay"),
-            let returnKey = comps.valueOfQueryItem("returnKey"),
-            let ret = comps.valueOfQueryItem("ret"), let retIntValue = Int(ret),
-            let notifyStr = comps.valueOfQueryItem("notifyStr")
-        {
+        if  comps.path.hasSuffix("pay"), let ret = comps.valueOfQueryItem("ret"), let retIntValue = Int(ret) {
             if retIntValue == 0 {
                 shared.payCompletionHandler?(.success(()))
                 return true
             } else {
                 let response: [String: String] = [
                     "ret": ret,
-                    "returnKey": returnKey,
-                    "notifyStr": notifyStr
+                    "returnKey": comps.valueOfQueryItem("returnKey") ?? "",
+                    "notifyStr": comps.valueOfQueryItem("notifyStr") ?? ""
                 ]
                 shared.payCompletionHandler?(.failure(.apiRequest(.unrecognizedError(response: response))))
                 return false

--- a/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
+++ b/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
@@ -45,6 +45,7 @@ extension MonkeyKing {
             wechatAuthToken = authToken
 
             lastMessage.map { deliver($0) { _ in } }
+            return true
         }
 
         // MARK: - oauth
@@ -52,8 +53,27 @@ extension MonkeyKing {
             return handleWechatOAuth(code: code)
         }
 
+        // MARK: - pay
+        if  comps.path.hasSuffix("pay"),
+            let returnKey = comps.valueOfQueryItem("returnKey"),
+            let ret = comps.valueOfQueryItem("ret"), let retIntValue = Int(ret),
+            let notifyStr = comps.valueOfQueryItem("notifyStr")
+        {
+            if retIntValue == 0 {
+                shared.payCompletionHandler?(.success(()))
+                return true
+            } else {
+                let response: [String: String] = [
+                    "ret": ret,
+                    "returnKey": returnKey,
+                    "notifyStr": notifyStr
+                ]
+                shared.payCompletionHandler?(.failure(.apiRequest(.unrecognizedError(response: response))))
+                return false
+            }
+        }
+
         // TODO: handle `resendContextReqByScheme`
-        // TODO: handle `pay`
         // TODO: handle `jointpay`
         // TODO: handle `offlinepay`
         // TODO: handle `cardPackage`

--- a/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
+++ b/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
@@ -33,10 +33,13 @@ extension MonkeyKing {
 
     // MARK: - Wechat Universal Links
 
+    @discardableResult
     private class func handleWechatUniversalLink(_ url: URL) -> Bool {
         guard let comps = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
             return false
         }
+
+        lastMessage.map { deliver($0) { _ in lastMessage = nil } }
 
         // MARK: - update token
         if let authToken = comps.valueOfQueryItem("wechat_auth_token"), !authToken.isEmpty {
@@ -45,7 +48,6 @@ extension MonkeyKing {
 
         // MARK: - refreshToken
         if comps.path.hasSuffix("refreshToken") {
-            lastMessage.map { deliver($0) { _ in } }
             return true
         }
 

--- a/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
+++ b/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
@@ -341,9 +341,3 @@ extension MonkeyKing {
         return false
     }
 }
-
-private extension URLComponents {
-    func valueOfQueryItem(_ itemName: String) -> String? {
-        queryItems?.first(where: { $0.name == itemName })?.value
-    }
-}

--- a/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
+++ b/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
@@ -38,12 +38,13 @@ extension MonkeyKing {
             return false
         }
 
-        // MARK: - refreshToken
-        if  comps.path.hasSuffix("refreshToken"),
-            let authToken = comps.valueOfQueryItem("wechat_auth_token"), !authToken.isEmpty
-        {
+        // MARK: - update token
+        if let authToken = comps.valueOfQueryItem("wechat_auth_token"), !authToken.isEmpty {
             wechatAuthToken = authToken
+        }
 
+        // MARK: - refreshToken
+        if comps.path.hasSuffix("refreshToken") {
             lastMessage.map { deliver($0) { _ in } }
             return true
         }

--- a/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
+++ b/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
@@ -1,7 +1,50 @@
 
 import Foundation
+import Security
+
 
 extension MonkeyKing {
+
+    public class func handleOpenUserActivity(_ userActivity: NSUserActivity) {
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb else { return }
+        guard let url = userActivity.webpageURL, let urlComps = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return
+        }
+
+        // handle `refreshToken`
+        if urlComps.path.hasSuffix("refreshToken") {
+            guard let authToken = urlComps
+                .queryItems?
+                .filter({ $0.name.lowercased() == "wechat_auth_token" })
+                .first?
+                .value,
+                !authToken.isEmpty
+            else {
+                return
+            }
+
+            wechatAuthToken = authToken
+
+            if let msg = lastMessage {
+                deliver(msg) { _ in }
+            }
+        }
+
+        lastMessage = nil
+
+        // TODO: handle `resendContextReqByScheme`
+        // TODO: handle `oauth`
+        // TODO: handle `pay`
+        // TODO: handle `jointpay`
+        // TODO: handle `offlinepay`
+        // TODO: handle `cardPackage`
+        // TODO: handle `choosecard`
+        // TODO: handle `chooseinvoice`
+        // TODO: handle `openwebview`
+        // TODO: handle `openbusinesswebview`
+        // TODO: handle `openranklist`
+        // TODO: handle `opentypewebview`
+    }
 
     public class func handleOpenURL(_ url: URL) -> Bool {
 

--- a/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
+++ b/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
@@ -14,19 +14,23 @@ extension MonkeyKing {
             return false
         }
 
+        var isHandled = false
+
         switch weChatAccount {
         case .weChat(_, _, _, let wxUL):
             if let wxUL = wxUL, url.absoluteString.hasPrefix(wxUL) {
-                return handleWechatUniversalLink(url)
+                isHandled = handleWechatUniversalLink(url)
             }
 
         // TODO: handle universal link of qq
 
         default:
-            return false
+            ()
         }
 
-        return true
+        lastMessage = nil
+
+        return isHandled
     }
 
     // MARK: - Wechat Universal Links
@@ -37,11 +41,6 @@ extension MonkeyKing {
             return false
         }
 
-        if let msg = lastMessage {
-            deliver(msg) { _ in }
-        }
-        lastMessage = nil
-
         // MARK: - update token
         if let authToken = comps.valueOfQueryItem("wechat_auth_token"), !authToken.isEmpty {
             wechatAuthToken = authToken
@@ -49,6 +48,9 @@ extension MonkeyKing {
 
         // MARK: - refreshToken
         if comps.path.hasSuffix("refreshToken") {
+            if let msg = lastMessage {
+                deliver(msg, completionHandler: shared.deliverCompletionHandler ?? { _ in })
+            }
             return true
         }
 

--- a/Sources/MonkeyKing/MonkeyKing.swift
+++ b/Sources/MonkeyKing/MonkeyKing.swift
@@ -31,7 +31,7 @@ public class MonkeyKing: NSObject {
     private override init() {}
 
     public enum Account: Hashable {
-        case weChat(appID: String, appKey: String?, miniAppID: String?)
+        case weChat(appID: String, appKey: String?, miniAppID: String?, universalLink: String?)
         case qq(appID: String)
         case weibo(appID: String, appKey: String, redirectURL: String)
         case pocket(appID: String)
@@ -40,7 +40,7 @@ public class MonkeyKing: NSObject {
 
         public var appID: String {
             switch self {
-            case .weChat(let appID, _, _):
+            case .weChat(let appID, _, _, _):
                 return appID
             case .qq(let appID):
                 return appID
@@ -55,13 +55,22 @@ public class MonkeyKing: NSObject {
             }
         }
 
+        public var universalLink: String? {
+            switch self {
+            case .weChat(_, _, _, let universalLink):
+                return universalLink
+            default:
+                return nil
+            }
+        }
+
         public func hash(into hasher: inout Hasher) {
             hasher.combine(appID)
         }
 
         public static func == (lhs: MonkeyKing.Account, rhs: MonkeyKing.Account) -> Bool {
             switch (lhs, rhs) {
-            case (.weChat(let lappID, _, _), .weChat(let rappID, _, _)),
+            case (.weChat(let lappID, _, _, _), .weChat(let rappID, _, _, _)),
                  (.qq(let lappID), .qq(let rappID)),
                  (.weibo(let lappID, _, _), .weibo(let rappID, _, _)),
                  (.pocket(let lappID), .pocket(let rappID)),


### PR DESCRIPTION
为了解决『未验证应用』的问题，需要支持 Universal Link。
通过逆向分析 `libWeChatSDK.a`，找到 `wechat_auth_token` 和 `wechat_auth_context_id` 的生成方式，生成有效的微信 Universal Link。

为保证兼容官方 SDK，也使用相同的 KeyChain 存储了 `wechat_auth_token`。

由于 SHA1 不可逆，且 hash 的字符串有部分是用 timeIntervalSince1970 生成，所以并没有按照微信的方法来生成 `wechat_auth_context_id`，理论上微信端是无法检测出来的。

目前只实现了以下功能：

- [x] `sendreq` - 分享，亲测上线后成功通过 universal link 分享后第二天可以去除『未验证应用』
- [x] `refreshToken` - 用于刷新 `wechat_auth_token`
- [x] `oauth`

还有以下 universal link 功能没有处理：

- [ ] `pay` - 仅兼容了 universal link 的接收，发送部分没有帐号可测试
- [ ] `resendContextReqByScheme`
- [ ] `jointpay`
- [ ] `offlinepay`
- [ ] `cardPackage`
- [ ] `choosecard`
- [ ] `chooseinvoice`
- [ ] `openwebview`
- [ ] `openbusinesswebview`
- [ ] `openranklist`
- [ ] `opentypewebview`

不依赖这些功能的话可以暂时直接使用[我的分支](https://github.com/lexrus/MonkeyKing)。