### PR TITLE
支持 QQ 的 Universal Link，避免「未验证应用」

### DIFF
--- a/China.xcodeproj/project.pbxproj
+++ b/China.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		7840AF1D1C63167C00AD5256 /* pay.php in Resources */ = {isa = PBXBuildFile; fileRef = 7840AF1C1C63167C00AD5256 /* pay.php */; };
 		955654EB1EB89D5D009444FF /* TwitterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955654EA1EB89D5D009444FF /* TwitterViewController.swift */; };
 		D71A624424D313E5002B2977 /* MonkeyKing+WeChatUniversalLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = D71A624324D313E5002B2977 /* MonkeyKing+WeChatUniversalLink.swift */; };
+		D79E9FD224F7628000821B95 /* MonkeyKing+QQUniversalLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = D79E9FD124F7628000821B95 /* MonkeyKing+QQUniversalLink.swift */; };
 		EDD0A28C213E6F7B003EB202 /* WeChatActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD0A28A213E6F7B003EB202 /* WeChatActivity.swift */; };
 		EDD0A28D213E6F7B003EB202 /* QQActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD0A28B213E6F7B003EB202 /* QQActivity.swift */; };
 		EDD0A28F213E6FB2003EB202 /* gif.gif in Resources */ = {isa = PBXBuildFile; fileRef = EDD0A28E213E6FB2003EB202 /* gif.gif */; };
@@ -105,6 +106,7 @@
 		7840AF1C1C63167C00AD5256 /* pay.php */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.php; path = pay.php; sourceTree = "<group>"; };
 		955654EA1EB89D5D009444FF /* TwitterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TwitterViewController.swift; sourceTree = "<group>"; };
 		D71A624324D313E5002B2977 /* MonkeyKing+WeChatUniversalLink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "MonkeyKing+WeChatUniversalLink.swift"; path = "Sources/MonkeyKing/MonkeyKing+WeChatUniversalLink.swift"; sourceTree = SOURCE_ROOT; };
+		D79E9FD124F7628000821B95 /* MonkeyKing+QQUniversalLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MonkeyKing+QQUniversalLink.swift"; sourceTree = "<group>"; };
 		D79F73B524920FBC00B4B883 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		D79F73B624920FBC00B4B883 /* MonkeyKing.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = MonkeyKing.podspec; sourceTree = "<group>"; };
 		D79F73B724920FBC00B4B883 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -190,6 +192,7 @@
 				10CDDF45237A8588005E8DE7 /* MonkeyKing+Error.swift */,
 				07211C7223B8D1AA0068A7C0 /* MonkeyKing+handleOpenURL.swift */,
 				D71A624324D313E5002B2977 /* MonkeyKing+WeChatUniversalLink.swift */,
+				D79E9FD124F7628000821B95 /* MonkeyKing+QQUniversalLink.swift */,
 				07211C7823B8D37E0068A7C0 /* MonkeyKing+Message.swift */,
 				07211C7A23B8D3A60068A7C0 /* MonkeyKing+OAuth.swift */,
 				07211C7E23B8D44C0068A7C0 /* MonkeyKing+OpenURL.swift */,
@@ -363,6 +366,7 @@
 				10CDDF4B237A8588005E8DE7 /* Extensions.swift in Sources */,
 				D71A624424D313E5002B2977 /* MonkeyKing+WeChatUniversalLink.swift in Sources */,
 				07211C7923B8D37E0068A7C0 /* MonkeyKing+Message.swift in Sources */,
+				D79E9FD224F7628000821B95 /* MonkeyKing+QQUniversalLink.swift in Sources */,
 				10CDDF49237A8588005E8DE7 /* AnyActivity.swift in Sources */,
 				07211C7723B8D2FD0068A7C0 /* MonkeyKing+Pay.swift in Sources */,
 				10CDDF46237A8588005E8DE7 /* MonkeyKing.swift in Sources */,

--- a/China/Activities/QQActivity.swift
+++ b/China/Activities/QQActivity.swift
@@ -36,7 +36,11 @@ class QQActivity: AnyActivity {
     }
 
     init(type: Type, message: MonkeyKing.Message, completionHandler: @escaping MonkeyKing.DeliverCompletionHandler) {
-        MonkeyKing.registerAccount(.qq(appID: Configs.QQ.appID))
+        MonkeyKing.registerAccount(
+            .qq(
+                appID: Configs.QQ.appID,
+                universalLink: Configs.QQ.universalLink
+            ))
         super.init(
             type: type.activityType,
             title: type.title,

--- a/China/AppDelegate.swift
+++ b/China/AppDelegate.swift
@@ -36,10 +36,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             SecItemDelete(spec)
         }
 
-        let defaults = UserDefaults.standard
-        let dictionary = defaults.dictionaryRepresentation()
-        dictionary.keys.forEach { key in
-            defaults.removeObject(forKey: key)
-        }
+        UserDefaults.standard
+            .dictionaryRepresentation().keys
+            .forEach(UserDefaults.standard.removeObject)
     }
 }

--- a/China/AppDelegate.swift
+++ b/China/AppDelegate.swift
@@ -8,6 +8,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func applicationDidFinishLaunching(_ application: UIApplication) {
+        if true {
+            clearAllLocalTokens()
+        }
+        
         MonkeyKing.registerLaunchFromWeChatMiniAppHandler { messageExt in
             print("messageExt:", messageExt)
         }
@@ -23,5 +27,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         return MonkeyKing.handleOpenUserActivity(userActivity)
+    }
+
+    private func clearAllLocalTokens() {
+        let secItemClasses = [kSecClassGenericPassword, kSecClassInternetPassword, kSecClassCertificate, kSecClassKey, kSecClassIdentity]
+        for itemClass in secItemClasses {
+            let spec: NSDictionary = [kSecClass: itemClass]
+            SecItemDelete(spec)
+        }
+
+        let defaults = UserDefaults.standard
+        let dictionary = defaults.dictionaryRepresentation()
+        dictionary.keys.forEach { key in
+            defaults.removeObject(forKey: key)
+        }
     }
 }

--- a/China/Configs.swift
+++ b/China/Configs.swift
@@ -18,6 +18,7 @@ struct Configs {
 
     struct QQ {
         static let appID = "1104881792"
+        static let universalLink = "YOUR_UNIVERSAL_LINK"
     }
 
     struct Pocket {

--- a/China/QQViewController.swift
+++ b/China/QQViewController.swift
@@ -4,7 +4,7 @@ import UIKit
 
 class QQViewController: UIViewController {
 
-    let account = MonkeyKing.Account.qq(appID: Configs.QQ.appID)
+    let account = MonkeyKing.Account.qq(appID: Configs.QQ.appID, universalLink: Configs.QQ.universalLink)
 
     @IBOutlet private var segmentControl: UISegmentedControl!
 

--- a/MonkeyKing/MonkeyKing+QQUniversalLink.swift
+++ b/MonkeyKing/MonkeyKing+QQUniversalLink.swift
@@ -1,0 +1,42 @@
+//
+//  MonkeyKing+QQUniversalLink.swift
+//  MonkeyKing
+//
+//  Created by Lex Tang on 2020/8/27.
+//  Copyright © 2020 nixWork. All rights reserved.
+//
+
+import Foundation
+
+extension MonkeyKing {
+
+    static var qqAppSignTxid: String? {
+        get {
+            return UserDefaults.standard.string(forKey: _txidKey)
+        }
+        set {
+            if newValue == nil {
+                UserDefaults.standard.removeObject(forKey: _txidKey)
+            } else {
+                UserDefaults.standard.set(newValue, forKey: _txidKey)
+            }
+        }
+    }
+
+    static var qqAppSignToken: String? {
+        get {
+            return UserDefaults.standard.string(forKey: _tokenKey)
+        }
+        set {
+            if newValue == nil {
+                UserDefaults.standard.removeObject(forKey: _tokenKey)
+            } else {
+                UserDefaults.standard.set(newValue, forKey: _tokenKey)
+            }
+        }
+    }
+
+}
+
+private let _txidKey = "_MonkeyKingQQAppSignTxid"
+private let _tokenKey = "_MonkeyKingQQAppSignToken"

--- a/MonkeyKing/MonkeyKing+QQUniversalLink.swift
+++ b/MonkeyKing/MonkeyKing+QQUniversalLink.swift
@@ -12,7 +12,7 @@ extension MonkeyKing {
 
     static var qqAppSignTxid: String? {
         get {
-            return UserDefaults.standard.string(forKey: _txidKey)
+            UserDefaults.standard.string(forKey: _txidKey)
         }
         set {
             if newValue == nil {
@@ -25,7 +25,7 @@ extension MonkeyKing {
 
     static var qqAppSignToken: String? {
         get {
-            return UserDefaults.standard.string(forKey: _tokenKey)
+            UserDefaults.standard.string(forKey: _tokenKey)
         }
         set {
             if newValue == nil {

--- a/Sources/MonkeyKing/Extensions.swift
+++ b/Sources/MonkeyKing/Extensions.swift
@@ -1,6 +1,6 @@
-
 import MobileCoreServices
 import UIKit
+import CommonCrypto
 
 extension Set {
 
@@ -85,6 +85,18 @@ extension String {
 
         return "QQ" + hexString
     }
+
+    // NOTE: Obviously, we don't even have to use CommonCrypto
+    // In order to reduce the package size, we'll replace this implenmentation some day
+    func sha1() -> String {
+        let data = Data(utf8)
+        var digest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
+        data.withUnsafeBytes {
+            _ = CC_SHA1($0.baseAddress, CC_LONG(data.count), &digest)
+        }
+        let hexBytes = digest.map { String(format: "%02hhx", $0) }
+        return hexBytes.joined()
+    }
 }
 
 extension Data {
@@ -93,6 +105,10 @@ extension Data {
         let json = try? JSONSerialization.jsonObject(with: self, options: .allowFragments)
 
         return json as? [String: Any]
+    }
+
+    var hexDescription: String {
+        reduce("") { $0 + String(format: "%02x", $1) }
     }
 }
 

--- a/Sources/MonkeyKing/MonkeyKing+Message.swift
+++ b/Sources/MonkeyKing/MonkeyKing+Message.swift
@@ -1,5 +1,5 @@
-
 import Foundation
+import UIKit
 
 extension MonkeyKing {
 

--- a/Sources/MonkeyKing/MonkeyKing+Message.swift
+++ b/Sources/MonkeyKing/MonkeyKing+Message.swift
@@ -336,6 +336,8 @@ extension MonkeyKing {
                     if let thumbnail = type.info.thumbnail, let thumbnailData = thumbnail.jpegData(compressionQuality: 0.9) {
                         dic["previewimagedata"] = thumbnailData
                     }
+                    // TODO: handle previewimageUrl string aswell
+
                     if let oldText = UIPasteboard.general.oldText {
                         dic["pasted_string"] = oldText
                     }
@@ -377,7 +379,7 @@ extension MonkeyKing {
                 if let encodedDescription = type.info.description?.monkeyking_base64AndURLEncodedString {
                     qqSchemeURLString += "&objectlocation=pasteboard&description=\(encodedDescription)"
                 }
-                qqSchemeURLString += "&sdkv=2.9"
+                qqSchemeURLString += "&sdkv=3.3.9_lite"
 
             } else { // Share Text
                 // fix #75
@@ -392,10 +394,29 @@ extension MonkeyKing {
                 }
             }
 
-            guard let url = URL(string: qqSchemeURLString) else {
+            guard var comps = URLComponents(string: qqSchemeURLString) else {
+                return
+            }
+
+            if account.universalLink != nil {
+                comps.scheme = "https"
+                comps.host = "qm.qq.com"
+                comps.path = "/opensdkul/mqqapi/share/to_fri"
+
+                if let token = qqAppSignToken {
+                    comps.queryItems?.append(.init(name: "appsign_token", value: token))
+                }
+                if let txid = qqAppSignTxid {
+                    comps.queryItems?.append(.init(name: "appsign_txid", value: txid))
+                }
+            }
+
+            guard let url = comps.url else {
                 completionHandler(.failure(.sdk(.urlEncodeFailed)))
                 return
             }
+
+            lastMessage = message
 
             shared.openURL(url) { flag in
                 if flag { return }

--- a/Sources/MonkeyKing/MonkeyKing+OAuth.swift
+++ b/Sources/MonkeyKing/MonkeyKing+OAuth.swift
@@ -92,18 +92,18 @@ extension MonkeyKing {
                     completionHandler(.failure(.sdk(.invalidURLScheme)))
                 }
             }
-        case .qq(let appID):
+        case .qq(let appID, _):
             let scope = scope ?? ""
             guard !platform.isAppInstalled else {
                 let appName = Bundle.main.monkeyking_displayName ?? "nixApp"
-                let dic = [
+                let dic: [String: Any] = [
                     "app_id": appID,
                     "app_name": appName,
                     "client_id": appID,
                     "response_type": "token",
                     "scope": scope,
                     "sdkp": "i",
-                    "sdkv": "2.9",
+                    "sdkv": "3.3.9_lite",
                     "status_machine": UIDevice.current.model,
                     "status_os": UIDevice.current.systemVersion,
                     "status_version": UIDevice.current.systemVersion,

--- a/Sources/MonkeyKing/MonkeyKing+WeChatUniversalLink.swift
+++ b/Sources/MonkeyKing/MonkeyKing+WeChatUniversalLink.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import Security
-import CommonCrypto
 
 
 extension MonkeyKing {
@@ -127,27 +126,6 @@ extension MonkeyKing {
         UIPasteboard.general.setData(data, forPasteboardType: "content")
     }
 
-}
-
-extension String {
-
-    // NOTE: Obviously, we don't even have to use CommonCrypto
-    // In order to reduce the package size, we'll replace this implenmentation some day
-    func sha1() -> String {
-        let data = Data(utf8)
-        var digest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
-        data.withUnsafeBytes {
-            _ = CC_SHA1($0.baseAddress, CC_LONG(data.count), &digest)
-        }
-        let hexBytes = digest.map { String(format: "%02hhx", $0) }
-        return hexBytes.joined()
-    }
-}
-
-extension Data {
-    var hexDescription: String {
-        reduce("") { $0 + String(format: "%02x", $1) }
-    }
 }
 
 private var _autoIncreaseId: UInt64 = 0

--- a/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
+++ b/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
@@ -1,4 +1,4 @@
-
+import UIKit
 import Foundation
 import Security
 
@@ -257,18 +257,15 @@ extension MonkeyKing {
 
 
         if let ul = account.universalLink, url.absoluteString.hasPrefix(ul) {
-            if let error = error {
-                shared.deliverCompletionHandler?(.failure(error))
-            } else {
-                shared.deliverCompletionHandler?(.success(nil))
-            }
+            let result = error.map(Result<ResponseJSON?, Error>.failure) ?? .success(nil)
+            shared.deliverCompletionHandler?(result)
             return true
         }
 
-        // OAuth is the only left
+        // OAuth is the only leftover
         guard let result = info["ret"] as? Int, result == 0 else {
             let error: Error
-            if let errorDomatin = info["user_cancelled"] as? String, errorDomatin == "YES" {
+            if let errorDomatin = info["user_cancelled"] as? String, errorDomatin.uppercased() == "YES" {
                 error = .userCancelled
             } else {
                 error = .apiRequest(.unrecognizedError(response: nil))

--- a/Sources/MonkeyKing/MonkeyKing.swift
+++ b/Sources/MonkeyKing/MonkeyKing.swift
@@ -32,7 +32,7 @@ public class MonkeyKing: NSObject {
 
     public enum Account: Hashable {
         case weChat(appID: String, appKey: String?, miniAppID: String?, universalLink: String?)
-        case qq(appID: String)
+        case qq(appID: String, universalLink: String?)
         case weibo(appID: String, appKey: String, redirectURL: String)
         case pocket(appID: String)
         case alipay(appID: String)
@@ -42,7 +42,7 @@ public class MonkeyKing: NSObject {
             switch self {
             case .weChat(let appID, _, _, _):
                 return appID
-            case .qq(let appID):
+            case .qq(let appID, _):
                 return appID
             case .weibo(let appID, _, _):
                 return appID
@@ -57,7 +57,7 @@ public class MonkeyKing: NSObject {
 
         public var universalLink: String? {
             switch self {
-            case .weChat(_, _, _, let universalLink):
+            case .weChat(_, _, _, let universalLink), .qq(_, let universalLink):
                 return universalLink
             default:
                 return nil
@@ -71,7 +71,7 @@ public class MonkeyKing: NSObject {
         public static func == (lhs: MonkeyKing.Account, rhs: MonkeyKing.Account) -> Bool {
             switch (lhs, rhs) {
             case (.weChat(let lappID, _, _, _), .weChat(let rappID, _, _, _)),
-                 (.qq(let lappID), .qq(let rappID)),
+                 (.qq(let lappID, _), .qq(let rappID, _)),
                  (.weibo(let lappID, _, _), .weibo(let rappID, _, _)),
                  (.pocket(let lappID), .pocket(let rappID)),
                  (.alipay(let lappID), .alipay(let rappID)),


### PR DESCRIPTION
拿我自己的 app 和公司的 app 都试了一下，OAuth 和分享都没有问题了，发起分享请求和回调都会通过 universal link 进行。并且，如果 app 中没有设置 applinks: 的话，也会兜底走 tencent**** 的 scheme 回调获取结果信息。

一边逆向一边写的代码，有一些重复的逻辑，之后会整理一下。麻烦各位有需求的可以测试一下我这个分支。

另外，这个 PR 同时修正了 #142 #108
