### PR TITLE
fix: QQ 登录与分享顺序错误

### DIFF
--- a/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
+++ b/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
@@ -343,7 +343,7 @@ extension MonkeyKing {
 
             var error: Error?
 
-            let success = (errorDescription == "0")
+            var success = (errorDescription == "0")
             if success {
                 error = nil
             } else {
@@ -354,7 +354,7 @@ extension MonkeyKing {
 
             // OAuth
             if url.path.contains("mqzone") {
-                handleQQCallbackResult(url: url, error: error)
+                success = handleQQCallbackResult(url: url, error: error)
             }
             // Share
             else {

--- a/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
+++ b/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
@@ -205,6 +205,17 @@ extension MonkeyKing {
     private class func handleQQCallbackResult(url: URL, error: Error?) -> Bool {
         guard let account = shared.accountSet[.qq] else { return false }
 
+        // Share
+        // Pasteboard is empty
+        if
+            let ul = account.universalLink,
+            url.absoluteString.hasPrefix(ul),
+            url.path.contains("response_from_qq") {
+            let result = error.map(Result<ResponseJSON?, Error>.failure) ?? .success(nil)
+            shared.deliverCompletionHandler?(result)
+            return true
+        }
+
         // OpenApi.m:131 getDictionaryFromGeneralPasteBoard
         guard
             let data = UIPasteboard.general.data(forPasteboardType: "com.tencent.tencent\(account.appID)"),
@@ -252,13 +263,6 @@ extension MonkeyKing {
             // The dictionary also contains "appsign_retcode=25105" and "appsign_bundlenull=2"
             // We don't have to handle them yet.
 
-            return true
-        }
-
-
-        if let ul = account.universalLink, url.absoluteString.hasPrefix(ul) {
-            let result = error.map(Result<ResponseJSON?, Error>.failure) ?? .success(nil)
-            shared.deliverCompletionHandler?(result)
             return true
         }
 

--- a/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
+++ b/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
@@ -350,11 +350,7 @@ extension MonkeyKing {
 
             // OAuth
             if url.path.contains("mqzone") {
-                if let error = error {
-                    shared.oauthCompletionHandler?(.failure(error))
-                } else {
-                    shared.oauthCompletionHandler?(.success(nil))
-                }
+                handleQQCallbackResult(url: url, error: error)
             }
             // Share
             else {


### PR DESCRIPTION
环境：
- iOS 14.3
- QQ 8.4.17.638

1. 当 AASA 文件没有加载完成时，QQ 使用 `URL Scheme` 处理登录请求，不应该调用 `shared.oauthCompletionHandler?(.success(nil))` 返回空数据；
2. 原先的分享回调一定会命中，导致下面的登录回调无法执行，现在提到更前面并增加 `response_from_qq` 判断。
