### PR TITLE
change: unified binary target and source target module name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,39 +4,25 @@ import PackageDescription
 
 let package = Package(
     name: "MonkeyKing",
-    platforms: [
-        .iOS(.v9),
-    ],
+    platforms: [.iOS(.v9)],
     products: [
         .library(
-            name: "MonkeyKingStatic",
-            type: .static,
-            targets: ["MonkeyKingSource"]
-        ),
-        .library(
-            name: "MonkeyKingDynamic",
-            type: .dynamic,
-            targets: ["MonkeyKingSource"]
-        ),
-        .library(
-            name: "MonkeyKingXCFramework",
+            name: "MonkeyKing",
             targets: ["MonkeyKing"]
         ),
+        .library(name: "MonkeyKingBinary", targets: ["MonkeyKingBinary"])
     ],
     targets: [
-        .target(
-            name: "MonkeyKingSource",
-            path: "Sources/MonkeyKing"
-        ),
+        .target(name: "MonkeyKing"),
         .testTarget(
             name: "MonkeyKingTests",
             dependencies: ["MonkeyKing"],
             path: "Tests/MonkeyKingTests"
         ),
         .binaryTarget(
-            name: "MonkeyKing",
-            url: "https://github.com/nixzhu/MonkeyKing/releases/download/2.1.0/MonkeyKing.xcframework.zip",
-            checksum: "80fb1624d14be17687867c6046abc62e0b92cd183882acf036158dc3b9570013"
-        ),
+                    name: "MonkeyKingBinary",
+                    url: "https://github.com/CodeEagle/MonkeyKing/releases/download/2.2.0/MonkeyKingBinary.xcframework.zip",
+                    checksum: "c186cb3a81a2a9b4434632829ff83f7f4c2b16ab119bf175d1e2e0a5bd88fed3"
+                ),
     ]
 )

--- a/Sources/MonkeyKing/MonkeyKing+OAuth.swift
+++ b/Sources/MonkeyKing/MonkeyKing+OAuth.swift
@@ -1,5 +1,5 @@
 
-import Foundation
+import UIKit
 
 extension MonkeyKing {
 

--- a/Sources/MonkeyKing/MonkeyKing+OpenURL.swift
+++ b/Sources/MonkeyKing/MonkeyKing+OpenURL.swift
@@ -1,5 +1,5 @@
 
-import Foundation
+import UIKit
 
 extension MonkeyKing {
 

--- a/Sources/MonkeyKing/MonkeyKing+WeChatUniversalLink.swift
+++ b/Sources/MonkeyKing/MonkeyKing+WeChatUniversalLink.swift
@@ -1,5 +1,5 @@
 
-import Foundation
+import UIKit
 import Security
 
 extension MonkeyKing {


### PR DESCRIPTION
By changing the `MonkeyKing.xcframework` to `MonkeyKingBinary.xcframework` (also `MonkeyKing.xcframework.zip` -> `MonkeyKingBinary.xcframework.zip` ) for the binary target, 
We now can use `MonkeyKing` as original Module name,
for both binary or source code target

```swift
let package = Package(
    name: "MonkeyKing",
    platforms: [.iOS(.v9)],
    products: [
        .library(
            name: "MonkeyKing",
            targets: ["MonkeyKing"]
        ),
        .library(name: "MonkeyKingBinary", targets: ["MonkeyKingBinary"])
    ],
    targets: [
        .target(name: "MonkeyKing"),
        .testTarget(
            name: "MonkeyKingTests",
            dependencies: ["MonkeyKing"],
            path: "Tests/MonkeyKingTests"
        ),
        .binaryTarget(
                    name: "MonkeyKingBinary",
                    url: "https://github.com/CodeEagle/MonkeyKing/releases/download/2.2.0/MonkeyKingBinary.xcframework.zip",
                    checksum: "c186cb3a81a2a9b4434632829ff83f7f4c2b16ab119bf175d1e2e0a5bd88fed3"
                ),
    ]
)
```