### PR TITLE
升级微信SDK version

### DIFF
--- a/China.xcodeproj/project.pbxproj
+++ b/China.xcodeproj/project.pbxproj
@@ -537,6 +537,7 @@
 				CURRENT_PROJECT_VERSION = 49;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = China/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nixWork.China;
@@ -556,6 +557,7 @@
 				CURRENT_PROJECT_VERSION = 49;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = China/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nixWork.China;
@@ -578,7 +580,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = MonkeyKing/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nixWork.MonkeyKing;
@@ -606,7 +608,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = MonkeyKing/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nixWork.MonkeyKing;

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "MonkeyKing",
-    platforms: [.iOS(.v9)],
+    platforms: [.iOS(.v11)],
     products: [
         .library(
             name: "MonkeyKing",

--- a/Sources/MonkeyKing/Helpers.swift
+++ b/Sources/MonkeyKing/Helpers.swift
@@ -274,12 +274,8 @@ extension MonkeyKing {
             return
         }
 
-        if #available(iOS 10.0, *) {
-            UIApplication.shared.open(url, options: options) { flag in
-                completion?(flag)
-            }
-        } else {
-            completion?(UIApplication.shared.openURL(url))
+        UIApplication.shared.open(url, options: options) { flag in
+            completion?(flag)
         }
     }
 

--- a/Sources/MonkeyKing/MonkeyKing+Message.swift
+++ b/Sources/MonkeyKing/MonkeyKing+Message.swift
@@ -289,9 +289,8 @@ extension MonkeyKing {
             shared.setPasteboard(of: appID, with: weChatMessageInfo)
 
             if
-                let commandUniversalLink = shared.wechatUniversalLink(of: "sendreq"), #available(iOS 10.0, *),
-                let universalLink = MonkeyKing.shared.accountSet[.weChat]?.universalLink,
-                let ulURL = URL(string: commandUniversalLink)
+                let ulURL = shared.wechatUniversalLink(of: "sendreq"),
+                let universalLink = MonkeyKing.shared.accountSet[.weChat]?.universalLink
             {
                 weChatMessageInfo["universalLink"] = universalLink
                 weChatMessageInfo["isAutoResend"] = false
@@ -420,7 +419,7 @@ extension MonkeyKing {
                 if let txid = qqAppSignTxid {
                     ulComps.queryItems?.append(.init(name: "appsign_txid", value: txid))
                 }
-                if let ulURL = ulComps.url, #available(iOS 10.0, *) {
+                if let ulURL = ulComps.url {
                     shared.openURL(ulURL, options: [.universalLinksOnly: true]) { succeed in
                         if !succeed {
                             fallbackToScheme(url: url, completionHandler: completionHandler)
@@ -501,7 +500,6 @@ extension MonkeyKing {
                 }
 
                 if account.universalLink != nil,
-                   #available(iOS 10.0, *),
                    let ulURL = weiboUniversalLink(query: url.query) {
                         shared.openURL(ulURL, options: [.universalLinksOnly: true]) { succeed in
                             if !succeed {

--- a/Sources/MonkeyKing/MonkeyKing+OpenURL.swift
+++ b/Sources/MonkeyKing/MonkeyKing+OpenURL.swift
@@ -16,15 +16,8 @@ extension MonkeyKing {
         }
 
         if let url = URL(string: scheme) {
-            if #available(iOS 10.0, *) {
-                UIApplication.shared.open(url, options: options) { flag in
-                    if !flag {
-                        handleErrorResult()
-                    }
-                }
-            } else {
-                let resutl = UIApplication.shared.openURL(url)
-                if !resutl {
+            UIApplication.shared.open(url, options: options) { flag in
+                if !flag {
                     handleErrorResult()
                 }
             }

--- a/Sources/MonkeyKing/MonkeyKing+WeChatUniversalLink.swift
+++ b/Sources/MonkeyKing/MonkeyKing+WeChatUniversalLink.swift
@@ -74,12 +74,9 @@ extension MonkeyKing {
         }
     }
 
-    func wechatUniversalLink(of command: String) -> String? {
-        guard
-            #available(iOS 10.0, *),
-            let account = MonkeyKing.shared.accountSet[.weChat],
-            account.universalLink != nil
-        else {
+    func wechatUniversalLink(of command: String, items: [URLQueryItem] = []) -> URL? {
+        guard let account = MonkeyKing.shared.accountSet[.weChat],
+              account.universalLink != nil else {
             return nil
         }
 
@@ -88,19 +85,21 @@ extension MonkeyKing {
         let bundleId = Bundle.main.bundleIdentifier ?? ""
         let allowedCharacterSet = CharacterSet(charactersIn: "!*'();:@&=+$,/?%#[] ^").inverted
 
-        if  let authToken = MonkeyKing.wechatAuthToken,
-            let authTokenEncoded = NSString(string: authToken).addingPercentEncoding(withAllowedCharacters: allowedCharacterSet)
-        {
-            return "https://help.wechat.com/app/\(appID)/\(command)/?wechat_auth_token=\(authTokenEncoded)&wechat_auth_context_id=\(contextId)&wechat_app_bundleId=\(bundleId)"
-        } else {
-            return "https://help.wechat.com/app/\(appID)/\(command)/?wechat_auth_context_id=\(contextId)&wechat_app_bundleId=\(bundleId)"
-        }
+        var queryItems = [
+            URLQueryItem(name: "wechat_auth_context_id", value: contextId),
+            URLQueryItem(name: "wechat_app_bundleId", value: bundleId)
+        ]
+        queryItems.append(contentsOf: items)
+
+        var urlComponents = URLComponents(string: "https://help.wechat.com/app/\(appID)/\(command)/")
+        urlComponents?.queryItems = queryItems
+        return urlComponents?.url
     }
 
     func setPasteboard(of appId: String, with content: [String: Any]) {
         var weChatMessageInfo: [String: Any] = [
             "result": "1",
-            "sdkver": "1.8.7.1",
+            "sdkver": "1.9.2",
             "returnFromApp": "0",
         ]
 

--- a/Sources/MonkeyKing/MonkeyKing+WeChatUniversalLink.swift
+++ b/Sources/MonkeyKing/MonkeyKing+WeChatUniversalLink.swift
@@ -91,6 +91,10 @@ extension MonkeyKing {
         ]
         queryItems.append(contentsOf: items)
 
+        if  let authToken = MonkeyKing.wechatAuthToken,
+            let authTokenEncoded = authToken.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) {
+            queryItems.append(URLQueryItem(name: "wechat_auth_token", value: authTokenEncoded))
+        }
         var urlComponents = URLComponents(string: "https://help.wechat.com/app/\(appID)/\(command)/")
         urlComponents?.queryItems = queryItems
         return urlComponents?.url

--- a/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
+++ b/Sources/MonkeyKing/MonkeyKing+handleOpenURL.swift
@@ -257,7 +257,7 @@ extension MonkeyKing {
 
             // Try to open the redirect url provided above
             if let redirectUrl = redirectComps.url, UIApplication.shared.canOpenURL(redirectUrl) {
-                UIApplication.shared.openURL(redirectUrl)
+                UIApplication.shared.open(redirectUrl)
             }
 
             // Otherwise we just send last message again
@@ -357,7 +357,7 @@ extension MonkeyKing {
         if urlScheme.hasPrefix("wx") {
             let urlString = url.absoluteString
             // OAuth
-            if urlString.contains("state=Weixinauth") {
+            if urlString.contains("state=") {
                 let queryDictionary = url.monkeyking_queryDictionary
                 guard let code = queryDictionary["code"] else {
                     shared.oauthFromWeChatCodeCompletionHandler = nil


### PR DESCRIPTION
* 最低支持iOS 11，与微信对齐
* 微信`sdkver`从`1.8.7.1`升级至`1.9.2`
* `weChatOAuthForCode`逻辑修改，新的逻辑与微信1.9.2版本SDK对齐，不再需要确认弹窗